### PR TITLE
Update MSI install ContentURL to enterpriseenrollment.pocmdmserver.com

### DIFF
--- a/mdm_server_poc/sample_syncml_commands/enterprisedesktopappmanagement_install_payload.xml
+++ b/mdm_server_poc/sample_syncml_commands/enterprisedesktopappmanagement_install_payload.xml
@@ -16,7 +16,7 @@
 							&lt;Product Version="1.0.0.0"&gt;
 								&lt;Download&gt;
 									&lt;ContentURLList&gt;
-										&lt;ContentURL&gt;https://mdmwindows.com/static/payload.msi&lt;/ContentURL&gt;
+										&lt;ContentURL&gt;https://enterpriseenrollment.pocmdmserver.com/static/payload.msi&lt;/ContentURL&gt;
 									&lt;/ContentURLList&gt;
 								&lt;/Download&gt;
 								&lt;Validation&gt;


### PR DESCRIPTION
The documentation on https://github.com/marcosd4h/mdm/tree/main/mdm_server_poc seem geared towards using "enterpriseenrollment.pocmdmserver.com" as DNS name for the MDM server. Therefore, proposing to update the MSI installation sample with matching `ContentURL` server name. The sample will then start working as expected by downloading and installing the `static/payload.msi` file from the MDM server.